### PR TITLE
chore: wire frasermolyneux-copilot MCP server (pinned v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,14 @@
 >
 > **Cloud agents (GitHub Copilot coding agent etc.):** read [`AGENTS.md`](../AGENTS.md) at the repo root first — it is the canonical brief that survives outside the local VS Code multi-root workspace.
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
+---
+
 ## Scope
 
 This Function App is intentionally small: it owns **scheduled maintenance** that needs to run away from the portal-web request path and the portal-server-agent / portal-server-events workers. Anything involving FTP, RCON, live stats, ban-file pushing, or log tailing now lives in [portal-server-agent](../../portal-server-agent/). Anything involving forum sync or map redirect lives in [portal-sync](../../portal-sync/). Real-time event ingest is in [portal-server-events](../../portal-server-events/).

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,23 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": [
+        "list_instructions",
+        "get_instruction",
+        "search_instructions",
+        "list_prompts",
+        "get_prompt",
+        "search_prompts",
+        "list_agents",
+        "get_agent",
+        "search_agents"
+      ]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           repository: frasermolyneux/.github-copilot
           path: .github-copilot
+          ref: refs/tags/v0.1.0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -42,3 +43,15 @@ jobs:
             dotnet-version: |
               9.0.x
               10.0.x
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+
+      - name: Build MCP server
+        shell: bash
+        working-directory: .github-copilot/mcp-server
+        run: |
+          npm ci
+          npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,12 @@ This file is the brief for the **GitHub Copilot coding agent** (and any other ag
 
 > If you are a human reading this in VS Code, prefer `.github/copilot-instructions.md` for project orientation. `AGENTS.md` is the agent execution brief.
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 ---
 
 ## Required reading (read these BEFORE doing any work)

--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 
 ## Security
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+Shared org conventions are served by the `frasermolyneux-copilot` MCP server (catalog in [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot)). For client config (`.vscode/mcp.json`, Copilot CLI, Claude Desktop) and the tool surface, see [`mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/main/mcp-server/README.md). Cloud agents pick it up automatically via [`.github/copilot/mcp_config.json`](.github/copilot/mcp_config.json) plus the `Build MCP server` step in [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml).


### PR DESCRIPTION
## Summary

Wires the `frasermolyneux-copilot` MCP server into this repo so MCP-capable agents (Copilot CLI, the GitHub Copilot coding agent, Claude Desktop, etc.) can query the org conventions catalog (`list_instructions`, `get_instruction`, `search_instructions`, plus the prompts/agents equivalents) instead of relying on stale assumptions. Mirrors the template already merged into `frasermolyneux/portal-core`, pinned to tag `v0.1.0` on `frasermolyneux/.github-copilot`.

## Type of change

- [x] chore / refactor
- [x] ci (GitHub Actions / Dependabot)
- [x] docs

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`metadata.copilot-instructions` via MCP for the canonical snippet)

## Validation evidence

### Build

```text
N/A - no runtime code touched. Workflow + docs + JSON config only.
```

### Tests

```text
N/A - no runtime code touched.
```

### Format check

```text
Test-Json .github\copilot\mcp_config.json -> True
python -c "import yaml; yaml.safe_load(open('.github/workflows/copilot-setup-steps.yml'))" -> yaml ok
```

### Other (lint, terraform plan summary, screenshots)

Snippet integrity verification (canonical "Org conventions via MCP" block sourced from the merged `frasermolyneux/portal-core` `AGENTS.md`):

```text
LF source bytes:     1094  sha256 a24d69ac15075f102f3d6a12bec5b7602b7193a3d32179b6b0e444281071b23f
Inserted CRLF form:  1100  sha256 4870388b27eae313f384187b9da4af42caa6b41c268021875994129fd09369c8
AGENTS.md inserted block:                  1100  sha256 4870388b...
.github/copilot-instructions.md inserted:  1100  sha256 4870388b...
Inter-file byte equality: True
```

## Risk and rollout

- **Blast radius:** Tooling only. No runtime code, no infrastructure, no published contracts. Affects how cloud agents and MCP-capable IDE clients resolve org conventions for this repo.
- **Auto-deploys on merge?** No. `copilot-setup-steps.yml` is only invoked by the Copilot coding agent runner and the workflow's own `workflow_dispatch`/path-filtered triggers. No deploy workflow touched.
- **Manual steps post-merge:** None. Cloud agents pick the MCP server up on their next run via the new `Build MCP server` step.
- **Rollback plan:** Revert the merge commit. There is no persistent state; reverting fully restores prior behaviour (file-only conventions load).

## Consumer impact

N/A - no published contract changed (no Abstractions / Api.Client packages / Service Bus DTOs / Terraform outputs touched).

## Reviewer focus areas

- `.github/workflows/copilot-setup-steps.yml`: the `Setup .NET` step is preserved untouched and the new `Setup Node.js` + `Build MCP server` steps are appended after it. Double-check step ordering and that the pinned `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4` SHA matches `portal-core` (it does).
- `.github/copilot/mcp_config.json` uses the explicit nine-tool list (matches in-prod `portal-core`), not a `["*"]` wildcard.
- The snippet inserted into `AGENTS.md` and `.github/copilot-instructions.md` is byte-identical across both files (SHA verified above).

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas** (no significant issues found).
- [x] PR body cites each acceptance criterion from the linked issue (task brief: five expected file changes - all present; snippet byte-identical across both files; JSON + YAML parse; `git status` shows only the expected paths).
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`).