### PR TITLE
hotfix: remove incompatible .WithCaching() from Repository client registration (fixes portal-repository-func startup crash after PR #838)

### DIFF
--- a/src/XtremeIdiots.Portal.Repository.App.Tests/Startup/RepositoryApiClientRegistrationTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.App.Tests/Startup/RepositoryApiClientRegistrationTests.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Client.Extensions;
+
+using XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1;
+using XtremeIdiots.Portal.Repository.Api.Client.V1;
+
+namespace XtremeIdiots.Portal.Repository.App.Tests.Startup;
+
+/// <summary>
+/// Regression tests that guard the Repository API client registration performed by
+/// <c>Program.cs</c>. PR #838 introduced <c>.WithCaching(c =&gt; c.UseLibraryDefaults())</c>
+/// against Repository Api.Client 4.2.21, which shares the caching configure action across
+/// every typed subclient and evaluates cache expressions during startup. That produced
+/// <see cref="ArgumentException"/> messages like:
+///     "The expression must invoke a method declared by
+///      XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1.IAdminActionsApi
+///      or one of its inherited interfaces."
+///
+/// The tests below mirror the production registration and force DI resolution of the
+/// aggregate client and the representative subclients that are used by this Function App.
+/// If a future change re-adds an incompatible consumer-side cache configuration, those
+/// registrations will throw during construction and these tests will fail fast.
+/// </summary>
+public sealed class RepositoryApiClientRegistrationTests
+{
+    private const string BaseUrl = "https://repository-api.example.invalid";
+    private const string Audience = "api://portal-repository-tests";
+
+    private static ServiceProvider BuildProvider()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["RepositoryApi:BaseUrl"] = BaseUrl,
+                ["RepositoryApi:ApplicationAudience"] = Audience,
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Mirrors src/XtremeIdiots.Portal.Repository.App/Program.cs registration exactly.
+        services.AddRepositoryApiClient(options => options
+            .WithBaseUrl(configuration["RepositoryApi:BaseUrl"]!)
+            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"]!));
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    [Fact]
+    public void AddRepositoryApiClient_ResolvesAggregateClientWithoutThrowing()
+    {
+        using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+
+        var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+
+        Assert.NotNull(client);
+    }
+
+    /// <summary>
+    /// Force resolution of every typed subclient the Function App consumes at runtime.
+    /// The PR #838 crash surfaced when the shared caching configure action was applied to
+    /// each subclient - resolving them here guarantees we execute the same code path.
+    /// </summary>
+    [Fact]
+    public void AddRepositoryApiClient_ResolvesTypedSubclientsUsedByThisApp()
+    {
+        using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+
+        var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+
+        // Exercised by UnclaimedActionReminder - this is the exact subclient named in
+        // the production ArgumentException message.
+        Assert.NotNull(client.AdminActions);
+        Assert.NotNull(client.AdminActions.V1);
+
+        Assert.NotNull(client.UserProfiles);
+        Assert.NotNull(client.UserProfiles.V1);
+
+        Assert.NotNull(client.Notifications);
+        Assert.NotNull(client.Notifications.V1);
+
+        // Exercised by MapPopularity.
+        Assert.NotNull(client.Maps);
+        Assert.NotNull(client.Maps.V1);
+
+        // Exercised by DataMaintenance timers.
+        Assert.NotNull(client.DataMaintenance);
+        Assert.NotNull(client.DataMaintenance.V1);
+
+        // Exercised by VpnDetectedTagReconciler.
+        Assert.NotNull(client.Players);
+        Assert.NotNull(client.Players.V1);
+    }
+
+    [Fact]
+    public void AddRepositoryApiClient_RepresentativeSubclient_ResolvesAsIAdminActionsApi()
+    {
+        using var provider = BuildProvider();
+        using var scope = provider.CreateScope();
+
+        var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+
+        var adminActionsApi = client.AdminActions.V1;
+
+        Assert.NotNull(adminActionsApi);
+        Assert.IsAssignableFrom<IAdminActionsApi>(adminActionsApi);
+    }
+
+    /// <summary>
+    /// Explicit witness that documents the PR #838 production crash: calling
+    /// <c>.WithCaching(c =&gt; c.UseLibraryDefaults())</c> against Repository Api.Client
+    /// 4.2.21 throws <see cref="ArgumentException"/> during startup - the failure surfaces
+    /// as soon as the typed client options are validated (or, in the observed production
+    /// stack, when the shared cache configure action is applied to a typed subclient such
+    /// as <see cref="IAdminActionsApi"/>).
+    ///
+    /// The purpose of this test is:
+    /// 1. Pin the exact failure mode that motivated the hotfix so it is not silently
+    ///    reintroduced.
+    /// 2. Fail loudly (turning green in an unexpected way) if a future MX.Api.Client /
+    ///    Repository Api.Client release fixes the consumer-side caching defect - at
+    ///    that point we can safely re-enable client-side caching in Program.cs.
+    /// </summary>
+    [Fact]
+    public void AddRepositoryApiClient_WithClientSideCaching_IsKnownIncompatibleWith_4_2_21()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var ex = Record.Exception(() =>
+        {
+            services.AddRepositoryApiClient(options => options
+                .WithBaseUrl(BaseUrl)
+                .WithEntraIdAuthentication(Audience)
+                .WithCaching(c => c.UseLibraryDefaults()));
+
+            using var provider = services.BuildServiceProvider(validateScopes: true);
+            using var scope = provider.CreateScope();
+            var client = scope.ServiceProvider.GetRequiredService<IRepositoryApiClient>();
+            _ = client.AdminActions.V1;
+        });
+
+        Assert.NotNull(ex);
+        Assert.IsAssignableFrom<ArgumentException>(ex);
+    }
+}

--- a/src/XtremeIdiots.Portal.Repository.App/Program.cs
+++ b/src/XtremeIdiots.Portal.Repository.App/Program.cs
@@ -10,7 +10,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 using MX.Api.Client.Extensions;
-using MX.Api.Client.Configuration;
 using MX.GeoLocation.Api.Client.V1;
 using MX.Observability.ApplicationInsights.WorkerService;
 using XtremeIdiots.Portal.Repository.Api.Client.V1;
@@ -80,8 +79,7 @@ var host = new HostBuilder()
 
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl(configuration["RepositoryApi:BaseUrl"] ?? throw new InvalidOperationException("RepositoryApi:BaseUrl configuration is required"))
-            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required"))
-            .WithCaching(c => c.UseLibraryDefaults()));
+            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required")));
 
         var geoBaseUrl = configuration["GeoLocationApi:BaseUrl"];
         var geoApiKey = configuration["GeoLocationApi:ApiKey"];


### PR DESCRIPTION
## Summary

Urgent production hotfix: portal-repository-func Function App is crashing at startup after PR #838 with `System.ArgumentException: The expression must invoke a method declared by XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1.IAdminActionsApi or one of its inherited interfaces. (Parameter ''expression'')`. This PR removes only the incompatible `.WithCaching(c => c.UseLibraryDefaults())` call while retaining Repository Api.Client 4.2.21 and MX.Api.Client 2.3.76.

Closes #

## Type of change

- [x] bugfix
- [ ] feature
- [ ] chore / refactor
- [ ] docs
- [ ] infra (Terraform)
- [ ] ci (GitHub Actions / Dependabot)
- [ ] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.*`, `patterns.*`, `platform.*`, `shared.*`)

## Root cause

PR #838 (commit b16df33) added `.WithCaching(c => c.UseLibraryDefaults())` on `AddRepositoryApiClient` at the same time it bumped `XtremeIdiots.Portal.Repository.Api.Client.V1` to `4.2.21` and `MX.Api.Client` to `2.3.76`.

Under Repository Api.Client 4.2.21, the caching configure action supplied to the aggregate client builder is applied to every typed subclient and cache expressions are evaluated during registration/resolution. `UseLibraryDefaults()` references members that do not belong to `IAdminActionsApi`, so subclient options validation throws:

```text
System.ArgumentException: The expression must invoke a method declared by
    XtremeIdiots.Portal.Repository.Abstractions.Interfaces.V1.IAdminActionsApi
    or one of its inherited interfaces. (Parameter ''expression'')
```

The Function worker never finishes host startup, so no timers run.

## Fix

Minimal, surgical:

- Remove only the `.WithCaching(c => c.UseLibraryDefaults())` call from `AddRepositoryApiClient` in [Program.cs](src/XtremeIdiots.Portal.Repository.App/Program.cs) plus the now-unused `using MX.Api.Client.Configuration;`. BaseUrl + Entra ID authentication registration is unchanged.
- **Retain `XtremeIdiots.Portal.Repository.Api.Client.V1` 4.2.21 and `MX.Api.Client` 2.3.76** - no package downgrades.
- **No alternative client-side caching introduced.** Repository server-side caching remains enabled and unaffected.
- All maintenance timers, paired HTTP triggers, health endpoints, and `VpnDetectedTagReconciler` behaviour are preserved. No Terraform, workflow, `version.json`, or unrelated dependency changes.

## Regression coverage

New file: [RepositoryApiClientRegistrationTests.cs](src/XtremeIdiots.Portal.Repository.App.Tests/Startup/RepositoryApiClientRegistrationTests.cs)

1. Mirrors the exact `AddRepositoryApiClient` registration used in `Program.cs`, builds a real `ServiceProvider`, opens a scope, and forces DI resolution of `IRepositoryApiClient` plus every typed subclient this Function App consumes (`AdminActions`, `UserProfiles`, `Notifications`, `Maps`, `DataMaintenance`, `Players`). `AdminActions` is the subclient named in the production exception.
2. Adds an explicit witness test `AddRepositoryApiClient_WithClientSideCaching_IsKnownIncompatibleWith_4_2_21` that asserts calling `.WithCaching(c => c.UseLibraryDefaults())` against 4.2.21 throws `ArgumentException` at startup. This pins the current incompatibility and is designed to flip green (fail) if a future upstream release fixes the defect, prompting a review of whether client-side caching can be safely re-enabled.

Limitations: because `Program.cs` uses top-level statements on `HostBuilder`, the tests re-declare the same registration rather than invoking Program directly. Divergence would require a follow-up refactor beyond a hotfix scope.

## Validation evidence

### Build

```text
dotnet build src\XtremeIdiots.Portal.Repository.App\XtremeIdiots.Portal.Repository.App.csproj

  XtremeIdiots.Portal.Repository.App -> ...\bin\Debug\net9.0\XtremeIdiots.Portal.Repository.App.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

### Tests

```text
dotnet test src --filter "FullyQualifiedName!~IntegrationTests"

Passed!  - Failed: 0, Passed: 30, Skipped: 0, Total: 30, Duration: 243 ms - XtremeIdiots.Portal.Repository.App.Tests.dll (net9.0)
```

Targeted registration tests:

```text
dotnet test ... --filter "FullyQualifiedName~RepositoryApiClientRegistrationTests"

Passed!  - Failed: 0, Passed: 4, Skipped: 0, Total: 4
```

### Format check

```text
dotnet format src --verify-no-changes
(no output = pass)
```

### Other

`code-review` sub-agent: **No significant issues found in the reviewed changes.**

## Risk and rollout

- **Blast radius:** portal-repository-func Function App only (scheduled maintenance: chat-message prune, game-server event/stat prune, system-assigned tag reset, map popularity rebuild, VPN tag reconciler, health endpoints). No shared contracts, DTOs, or Terraform touched. Portal Repository API server-side caching is untouched.
- **Auto-deploys on merge?** Yes - merging to `main` triggers `deploy-dev` and then `deploy-prd` per the standard CI/CD pipeline. This is the desired path to restore production.
- **Manual steps post-merge:** None. Confirm Function App boots cleanly and timer-triggered runs resume in Application Insights (look for `DataMaintenance.*`, `MapPopularity`, `VpnDetectedTagReconciler` operation names) once deploy-prd completes.
- **Rollback plan:** `git revert` this commit would return the app to the crashing PR #838 state, so revert is **not** a valid rollback. If a further defect surfaces from this change, rollback = revert both this commit and PR #838 (b16df33) to return to cd55205 (Repository Api.Client 4.2.16 / MX.Api.Client 2.3.75 baseline). No schema, config, secret, or Terraform state changes to unwind.

## Consumer impact

No published contract touched (no Abstractions, no Client NuGet, no Service Bus DTO, no Terraform outputs). Section not applicable.

## Reviewer focus areas

- Confirm removing `.WithCaching(...)` is acceptable as the fix-forward (product decision: client-side caching stays off until upstream fix; server-side caching in the Repository API is unaffected).
- Sanity check the witness test approach: it deliberately asserts the *broken* path throws so that a future upstream fix will surface as a failing test rather than silent behavioural drift.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas**
- [x] PR body cites each acceptance criterion from the linked issue
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)
