### PR TITLE
chore: re-enable Repository client L1 caching on 4.2.22 + add DI host-boot regression test

### DIFF
--- a/src/XtremeIdiots.Portal.Repository.App.Tests/StartupCompositionTests.cs
+++ b/src/XtremeIdiots.Portal.Repository.App.Tests/StartupCompositionTests.cs
@@ -63,6 +63,9 @@ public sealed class StartupCompositionTests
             typeof(IGameServersApi),
             typeof(IChatMessagesApi),
             typeof(IMapsApi),
+            typeof(IDataMaintenanceApi),
+            typeof(IUserProfileApi),
+            typeof(INotificationsApi),
         ];
     }
 
@@ -71,9 +74,14 @@ public sealed class StartupCompositionTests
         var services = new ServiceCollection();
         services.AddLogging();
 
+        // Must mirror Program.cs exactly, including .WithCaching(...) — this is the registration
+        // shape that crashed in production with Repository client 4.2.21 / MX.Api.Client 2.3.76
+        // (ArgumentException fanning a single cache delegate across every typed sub-API).
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl(BaseUrl)
-            .WithEntraIdAuthentication(Audience));
+            .WithEntraIdAuthentication(Audience)
+            .WithCachePartition("portal-repository-func")
+            .WithCaching(c => c.UseLibraryDefaults()));
 
         return services.BuildServiceProvider(validateScopes: true);
     }

--- a/src/XtremeIdiots.Portal.Repository.App/Program.cs
+++ b/src/XtremeIdiots.Portal.Repository.App/Program.cs
@@ -78,9 +78,23 @@ var host = new HostBuilder()
         services.ConfigureFunctionsApplicationInsights();
         services.AddObservability();
 
+        // Repository client L1 caching (re-enabled). The client library's default cache policies
+        // are scoped per typed sub-API by MX.Api.Client 2.3.77 SharedCacheConfiguration (consumed
+        // internally by Repository client 4.2.22), so the consumer-side .WithCaching(...) call no
+        // longer fans a single delegate across every sub-API and no longer throws at DI compose.
+        // This app only invokes DataMaintenance mutations (Prune*, Reset*), Maps.RebuildMapPopularity
+        // (mutation), Players.SetVpnDetectedTag (mutation) + a paged read, AdminActions/UserProfiles
+        // reads for reminders, and Notifications.CreateNotification (mutation). None of the timers
+        // performs a cached read followed by a mutation on the same key within one invocation, so
+        // enabling the library's read-only defaults is safe here — the default policies target
+        // GET operations only and every mutation this app performs uses a distinct verb/method,
+        // meaning any cached value for the read side would already have been fetched fresh at
+        // timer-fire time.
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl(configuration["RepositoryApi:BaseUrl"] ?? throw new InvalidOperationException("RepositoryApi:BaseUrl configuration is required"))
-            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required")));
+            .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required"))
+            .WithCachePartition("portal-repository-func")
+            .WithCaching(c => c.UseLibraryDefaults()));
 
         var geoBaseUrl = configuration["GeoLocationApi:BaseUrl"];
         var geoApiKey = configuration["GeoLocationApi:ApiKey"];

--- a/src/XtremeIdiots.Portal.Repository.App/Program.cs
+++ b/src/XtremeIdiots.Portal.Repository.App/Program.cs
@@ -82,14 +82,17 @@ var host = new HostBuilder()
         // are scoped per typed sub-API by MX.Api.Client 2.3.77 SharedCacheConfiguration (consumed
         // internally by Repository client 4.2.22), so the consumer-side .WithCaching(...) call no
         // longer fans a single delegate across every sub-API and no longer throws at DI compose.
-        // This app only invokes DataMaintenance mutations (Prune*, Reset*), Maps.RebuildMapPopularity
-        // (mutation), Players.SetVpnDetectedTag (mutation) + a paged read, AdminActions/UserProfiles
-        // reads for reminders, and Notifications.CreateNotification (mutation). None of the timers
-        // performs a cached read followed by a mutation on the same key within one invocation, so
-        // enabling the library's read-only defaults is safe here — the default policies target
-        // GET operations only and every mutation this app performs uses a distinct verb/method,
-        // meaning any cached value for the read side would already have been fetched fresh at
-        // timer-fire time.
+        //
+        // Safety: this app only invokes DataMaintenance mutations (Prune*, Reset*),
+        // Maps.RebuildMapPopularity (mutation), Players.SetVpnDetectedTag (mutation) plus a paged
+        // read of GetVpnDetectedTagReconciliationCandidates, AdminActions/UserProfiles reads for
+        // reminders, and Notifications.CreateNotification (mutation). The library's default policies
+        // only cache GET operations, and no timer in this app performs a cached read followed by a
+        // mutation of the same key. Note the L1 cache is process-scoped and can therefore outlive a
+        // single invocation while the Functions worker stays warm, so any staleness window is bounded
+        // by the library default TTL, not by the timer schedule — acceptable here because the reads
+        // above are advisory (reminder recipients, VPN tag reconciliation candidates) rather than
+        // authoritative reads that gate a subsequent write on the same key.
         services.AddRepositoryApiClient(options => options
             .WithBaseUrl(configuration["RepositoryApi:BaseUrl"] ?? throw new InvalidOperationException("RepositoryApi:BaseUrl configuration is required"))
             .WithEntraIdAuthentication(configuration["RepositoryApi:ApplicationAudience"] ?? throw new InvalidOperationException("RepositoryApi:ApplicationAudience configuration is required"))

--- a/src/XtremeIdiots.Portal.Repository.App/XtremeIdiots.Portal.Repository.App.csproj
+++ b/src/XtremeIdiots.Portal.Repository.App/XtremeIdiots.Portal.Repository.App.csproj
@@ -21,10 +21,10 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
-    <PackageReference Include="MX.Api.Client" Version="2.3.76" />
+    <PackageReference Include="MX.Api.Client" Version="2.3.77" />
     <PackageReference Include="MX.GeoLocation.Api.Client.V1" Version="1.2.96" />
     <PackageReference Include="MX.Observability.ApplicationInsights.WorkerService" Version="1.1.28" />
-    <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.21" />
+    <PackageReference Include="XtremeIdiots.Portal.Repository.Api.Client.V1" Version="4.2.22" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
## Summary

Re-enable Portal Repository client L1 caching on top of the fixed 4.2.22 / MX.Api.Client 2.3.77 pair (root cause of the outage is now fixed) and add a host-boot regression test that would have caught the original crash. Restores the caching that hotfix #839 removed and rolls PR #838 forward safely.

Closes #

## Type of change

- [ ] bugfix
- [ ] feature
- [x] chore / refactor
- [ ] docs
- [ ] infra (Terraform)
- [ ] ci (GitHub Actions / Dependabot)
- [x] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md`
- [x] `.github/copilot-instructions.md`
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md`
- [x] Stack-specific instruction files (`standards.dotnet-project`, `patterns.api-client`, `shared.api-client-abstractions`)

## Validation evidence

### Build

```text
$ dotnet build src
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:00:09.72
```

### Tests

```text
$ dotnet test src --filter "FullyQualifiedName!~IntegrationTests"
Passed!  - Failed:     0, Passed:    36, Skipped:     0, Total:    36, Duration: 278 ms - XtremeIdiots.Portal.Repository.App.Tests.dll (net9.0)
```

Confirmed the new `StartupCompositionTests` reproduce the pre-4.2.22 failure mode (`System.ArgumentException: The expression must invoke a method declared by IAdminActionsApi ...`) when run against 4.2.21 / 2.3.76 with `.WithCaching(...)`, and pass against 4.2.22 / 2.3.77.

### Format check

```text
$ dotnet format src --verify-no-changes
(no output — clean)
```

## Risk and rollout

- **Blast radius:** Single Function App (portal-repository-func) — 4 timer cleanups + map popularity rebuild + unclaimed action reminder + VPN tag reconciler. No infra changes.
- **Auto-deploys on merge?** Yes — `deploy-dev` runs on push to `main`; `deploy-prd` gated on the usual Terraform plan/apply.
- **Manual steps post-merge:** None.
- **Rollback plan:** Revert the commit. This restores the pre-caching registration (equivalent to PR #839's post-hotfix state) which is known-good. Terraform is untouched so no state to roll back.

## Consumer impact

No published contract touched; App-only change.

## Reviewer focus areas

- Correctness of `.WithCachePartition("portal-repository-func")` — the value is a stable, non-secret identifier for cache isolation. MX.Api.Client 2.3.77 requires it whenever caching is enabled.
- Safety of enabling `UseLibraryDefaults()` given this app performs mutations (Prune*, Reset*, RebuildMapPopularity, SetVpnDetectedTag, CreateNotification). Rationale in commit body and Program.cs comment: the app never performs a cached read followed by a mutation of the same key within a single invocation; the library defaults only cache GET operations.
- `StartupCompositionTests` mirrors Program.cs exactly (base URL + Entra + cache partition + `.WithCaching`) so any future regression that fans a cache delegate across sibling sub-APIs at DI compose will fail this test locally and in CI.

## Agent attestation

- [x] Ran `code-review` sub-agent; no High/Medium findings.
- [x] PR body cites each acceptance criterion from the task.
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced.
